### PR TITLE
Fix flipped bitangent direction

### DIFF
--- a/Shaders/Lit/Lit/Fragment.hlsl
+++ b/Shaders/Lit/Lit/Fragment.hlsl
@@ -35,7 +35,6 @@ half4 frag (v2f input, uint facing : SV_IsFrontFace) : SV_Target
         AACutout(surf.alpha, _Cutoff);
     #endif
 
-    surf.tangentNormal.g *= -1;
     FlipBTN(facing, input.worldNormal, input.bitangent, input.tangent);
 
     half3 indirectSpecular = 0.0;

--- a/Shaders/Lit/Lit/Vertex.hlsl
+++ b/Shaders/Lit/Lit/Vertex.hlsl
@@ -67,7 +67,7 @@ v2f vert (appdata_all v)
 
     o.worldNormal = UnityObjectToWorldNormal(v.normal);
     o.tangent = UnityObjectToWorldDir(v.tangent.xyz);
-    o.bitangent = cross(o.tangent, o.worldNormal) * v.tangent.w;
+    o.bitangent = cross(o.worldNormal, o.tangent) * v.tangent.w;
     o.worldPos = mul(unity_ObjectToWorld, v.vertex);
 
     #if defined(VERTEXLIGHT_ON) && !defined(VERTEXLIGHT_PS)


### PR DESCRIPTION
It's order-dependent, albeit mostly harmless. In this case it just mismatches with bitangent direction of your TBN map.

For the future: consider calculating bitangents in fragment to save on interpolator work. Works better for both tiled and immediate hardware.